### PR TITLE
Add support for extracting organisation name from certificate subject

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ example authsources.php entry:
         'authX509toSAML:cert_name_attribute': 'CN',
         'authX509toSAML:assertion_name_attribute': 'displayName',
         'authX509toSAML:assertion_dn_attribute': 'distinguishedName',
+        'authX509toSAML:assertion_o_attribute': 'o',
         'authX509toSAML:assetion_assurance_attribute': 'eduPersonAssurance',
         'authX509toSAML:parse_san_emails': TRUE
         'authX509toSAML:parse_policy': TRUE,
@@ -74,8 +75,13 @@ The configuration options are as following
                                  of the certificate subject will be mapped to
 * assertion_dn_attribute         is the attribute in the SAML assertion where the DN of the
                                  certificate subject will be mapped to
+
+* assertion_o_attribute          is the attribute in the SAML assertion where the organisation name (if present) 
+                                 in the certificate subject will be mapped to. Defaults to `'o'`. If set to `null`, the module will not attempt to extract the value from the certificate subject.
+
 * assertion_dn_attribute         is the attribute in the SAML assertion where the certificatePolicy 
                                  attribute of the certificate will be mapped to
+
 * parse_san_emails               controls whether the module will attempt to parse Subject Alternate
                                  Names to find possible email addresses for the certificate subject
 * parse_policy                   controls whether the module will attempt to parse Certificate Policy

--- a/lib/Auth/Source/X509userCert.php
+++ b/lib/Auth/Source/X509userCert.php
@@ -100,6 +100,11 @@ class sspmod_authX509toSAML_Auth_Source_X509userCert extends SimpleSAML_Auth_Sou
         } else {
             $assertion_dn_attribute = $this->config['authX509toSAML:assertion_dn_attribute'];
         }
+        if (!array_key_exists('authX509toSAML:assertion_o_attribute', $this->config)){
+            $assertion_o_attribute = 'o';
+        } elseif (!empty($this->config['authX509toSAML:assertion_o_attribute']) && is_string($this->config['authX509toSAML:assertion_o_attribute'])){
+            $assertion_o_attribute = $this->config['authX509toSAML:assertion_o_attribute'];
+        }
         if (!array_key_exists('authX509toSAML:assetion_assurance_attribute', $this->config)){
             $assertion_assurance_attribute = 'eduPersonAssurance';
         } else {
@@ -159,6 +164,10 @@ class sspmod_authX509toSAML_Auth_Source_X509userCert extends SimpleSAML_Auth_Sou
                     }
                 }
             }
+        }
+        // Attempt to parse organisation name from certificate subject
+        if (isset($assertion_o_attribute) && !empty($client_cert_data['subject']['O']) && is_string($client_cert_data['subject']['O'])){
+            $attributes[$assertion_o_attribute] = array($client_cert_data['subject']['O']);
         }
         // Attempt to parse certificatePolicies extensions
         if($parse_policy){


### PR DESCRIPTION
This PR adds support for extracting the organisation name from the certificate subject and adding it to the SAML attribute assertion. 

The name of the SAML attribute is controlled through the `assertion_o_attribute` module config parameter. Defaults to `'o'` (`urn:oid:2.5.4.10`). If set to `null`, the module will not attempt to extract the value from the certificate subject (see also updated README).